### PR TITLE
Allows deleting single cached item by unique ID

### DIFF
--- a/Sources/Classes/Storage/SZAVPlayerCache.swift
+++ b/Sources/Classes/Storage/SZAVPlayerCache.swift
@@ -40,6 +40,10 @@ public class SZAVPlayerCache: NSObject {
         trimCache()
     }
 
+    public func delete(uniqueID: String) {
+        SZAVPlayerDatabase.shared.trimData(uniqueID: uniqueID)
+    }
+
     public func cleanCache() {
         SZAVPlayerDatabase.shared.cleanData()
         SZAVPlayerFileSystem.cleanCachedFiles()

--- a/Sources/Classes/Storage/SZAVPlayerDatabase.swift
+++ b/Sources/Classes/Storage/SZAVPlayerDatabase.swift
@@ -40,18 +40,31 @@ public class SZAVPlayerDatabase: NSObject {
         }
     }
 
-    public func trimData() {
+    public func trimData(uniqueID: String? = nil) {
         DispatchQueue.global(qos: .background).async {
-            let infos = self.expiredContentInfos()
-            for info in infos {
-                self.deleteMIMEType(uniqueID: info.uniqueID)
+            func delete(fileInfo: SZAVPlayerLocalFileInfo) {
+                let fileURL = SZAVPlayerFileSystem.localFilePath(fileName: fileInfo.localFileName)
+                SZAVPlayerFileSystem.delete(url: fileURL)
+            }
 
-                let fileInfos = self.localFileInfos(uniqueID: info.uniqueID)
+            if let uniqueID = uniqueID, !uniqueID.isEmpty {
+                self.deleteMIMEType(uniqueID: uniqueID)
+                let fileInfos = self.localFileInfos(uniqueID: uniqueID)
                 for fileInfo in fileInfos {
-                    let fileURL = SZAVPlayerFileSystem.localFilePath(fileName: fileInfo.localFileName)
-                    SZAVPlayerFileSystem.delete(url: fileURL)
+                    delete(fileInfo: fileInfo)
                 }
-                self.deleteLocalFileInfo(uniqueID: info.uniqueID)
+                self.deleteLocalFileInfo(uniqueID: uniqueID)
+            } else {
+                let infos = self.expiredContentInfos()
+                for info in infos {
+                    self.deleteMIMEType(uniqueID: info.uniqueID)
+
+                    let fileInfos = self.localFileInfos(uniqueID: info.uniqueID)
+                    for fileInfo in fileInfos {
+                        delete(fileInfo: fileInfo)
+                    }
+                    self.deleteLocalFileInfo(uniqueID: info.uniqueID)
+                }
             }
         }
     }

--- a/Sources/Classes/Storage/SZAVPlayerDatabase.swift
+++ b/Sources/Classes/Storage/SZAVPlayerDatabase.swift
@@ -42,28 +42,12 @@ public class SZAVPlayerDatabase: NSObject {
 
     public func trimData(uniqueID: String? = nil) {
         DispatchQueue.global(qos: .background).async {
-            func delete(fileInfo: SZAVPlayerLocalFileInfo) {
-                let fileURL = SZAVPlayerFileSystem.localFilePath(fileName: fileInfo.localFileName)
-                SZAVPlayerFileSystem.delete(url: fileURL)
-            }
-
             if let uniqueID = uniqueID, !uniqueID.isEmpty {
-                self.deleteMIMEType(uniqueID: uniqueID)
-                let fileInfos = self.localFileInfos(uniqueID: uniqueID)
-                for fileInfo in fileInfos {
-                    delete(fileInfo: fileInfo)
-                }
-                self.deleteLocalFileInfo(uniqueID: uniqueID)
+                self.delete(uniqueID: uniqueID)
             } else {
                 let infos = self.expiredContentInfos()
                 for info in infos {
-                    self.deleteMIMEType(uniqueID: info.uniqueID)
-
-                    let fileInfos = self.localFileInfos(uniqueID: info.uniqueID)
-                    for fileInfo in fileInfos {
-                        delete(fileInfo: fileInfo)
-                    }
-                    self.deleteLocalFileInfo(uniqueID: info.uniqueID)
+                    self.delete(uniqueID: info.uniqueID)
                 }
             }
         }
@@ -238,4 +222,15 @@ private extension SZAVPlayerDatabase {
         }
     }
 
+    func delete(uniqueID: String) {
+        self.deleteMIMEType(uniqueID: uniqueID)
+
+        let fileInfos = self.localFileInfos(uniqueID: uniqueID)
+        for fileInfo in fileInfos {
+            let fileURL = SZAVPlayerFileSystem.localFilePath(fileName: fileInfo.localFileName)
+            SZAVPlayerFileSystem.delete(url: fileURL)
+        }
+        self.deleteLocalFileInfo(uniqueID: uniqueID)
+    }
+    
 }


### PR DESCRIPTION
Adds a method inside `SZAVPlayerCache` to make possible deleting single cached items using unique ID.

Usage: `SZAVPlayerCache.shared.delete(uniqueID: ...)`